### PR TITLE
Guard email verification prompt from unauthenticated guests

### DIFF
--- a/packages/panels/src/Auth/Pages/EmailVerification/EmailVerificationPrompt.php
+++ b/packages/panels/src/Auth/Pages/EmailVerification/EmailVerificationPrompt.php
@@ -13,6 +13,8 @@ use Filament\Schemas\Components\Text;
 use Filament\Schemas\Schema;
 use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Contracts\Support\Htmlable;
+use Illuminate\Http\Exceptions\HttpResponseException;
+use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\HtmlString;
 use LogicException;
 
@@ -32,8 +34,19 @@ class EmailVerificationPrompt extends SimplePage
 
     protected function getVerifiable(): MustVerifyEmail
     {
-        /** @var MustVerifyEmail $user */
         $user = Filament::auth()->user();
+
+        if ($user === null) {
+            $panel = Filament::getCurrentOrDefaultPanel();
+
+            if ($panel?->hasLogin()) {
+                throw new HttpResponseException(new RedirectResponse($panel->route('auth.login')));
+            }
+
+            abort(403);
+        }
+
+        /** @var MustVerifyEmail $user */
 
         return $user;
     }

--- a/tests/src/Panels/Auth/EmailVerification/EmailVerificationPromptTest.php
+++ b/tests/src/Panels/Auth/EmailVerification/EmailVerificationPromptTest.php
@@ -3,8 +3,10 @@
 use Filament\Auth\Notifications\VerifyEmail;
 use Filament\Auth\Pages\EmailVerification\EmailVerificationPrompt;
 use Filament\Facades\Filament;
+use Filament\Http\Middleware\Authenticate;
 use Filament\Tests\Fixtures\Models\User;
 use Filament\Tests\TestCase;
+use Illuminate\Auth\GenericUser;
 use Illuminate\Support\Facades\Notification;
 
 use function Filament\Tests\livewire;
@@ -77,4 +79,44 @@ it('can throttle resend notification attempts', function (): void {
         ->assertNotified();
 
     Notification::assertSentToTimes($userToVerify, VerifyEmail::class, times: 2);
+});
+
+it('redirects guests to the panel login route when unauthenticated', function (): void {
+    $this->withoutMiddleware(Authenticate::class);
+
+    $panel = Filament::getCurrentOrDefaultPanel();
+
+    expect($panel)->not()->toBeNull();
+    expect($panel?->hasLogin())->toBeTrue();
+    expect(Filament::getEmailVerificationPromptUrl())->not()->toBeNull();
+
+    $this->get(Filament::getEmailVerificationPromptUrl())
+        ->assertRedirect($panel?->route('auth.login'));
+});
+
+it('denies access to authenticated users who do not verify email addresses', function (): void {
+    $user = new GenericUser([
+        'id' => 1,
+        'email' => 'generic@example.com',
+    ]);
+
+    $this->be($user);
+
+    expect(Filament::getEmailVerificationPromptUrl())->not()->toBeNull();
+
+    $this->get(Filament::getEmailVerificationPromptUrl())
+        ->assertForbidden();
+});
+
+it('allows authenticated verifiable users to view the prompt', function (): void {
+    $this->withoutMiddleware(Authenticate::class);
+
+    $userToVerify = User::factory()->create([
+        'email_verified_at' => null,
+    ]);
+
+    $this->actingAs($userToVerify);
+
+    $this->get(Filament::getEmailVerificationPromptUrl())
+        ->assertOk();
 });


### PR DESCRIPTION
## Summary
- redirect unauthenticated visitors away from the email verification prompt using the owning panel's login route before resolving the verifiable user
- add regression coverage for guest redirects, non-verifiable users retaining the forbidden response, and verifiable users loading the prompt successfully

## Reproduction
- visit a panel configured with `->emailVerification()` and without the authenticate middleware as a guest
- open the email verification prompt route and observe a crash caused by `null` user access

## Fix Notes
- guard the prompt by redirecting to the panel-specific login route (or aborting with 403 when no login route exists) before resolving the verifiable user
- cover the regression with new HTTP feature tests across guest, non-verifiable, and verifiable scenarios
